### PR TITLE
Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
     - composer analyse
 
     - vendor/bin/phpspec run
-    - vendor/bin/phpunit
+    - vendor/bin/phpunit tests

--- a/src/Listener/SuiteLoaderListener.php
+++ b/src/Listener/SuiteLoaderListener.php
@@ -54,6 +54,7 @@ final class SuiteLoaderListener extends AbstractListener implements BeforeSuiteL
     {
         $optionsNode->children()
             ->arrayNode('suites')
+                ->requiresAtLeastOneElement()
                 ->performNoDeepMerging()
                 ->prototype('scalar')
             ->end();

--- a/src/Resources/config/services/listener.xml
+++ b/src/Resources/config/services/listener.xml
@@ -18,6 +18,13 @@
         <service id="sylius_fixtures.listener_registry" class="Sylius\Bundle\FixturesBundle\Listener\ListenerRegistry" public="false" />
         <service id="Sylius\Bundle\FixturesBundle\Listener\ListenerRegistryInterface" alias="sylius_fixtures.listener_registry" />
 
+        <service class="Sylius\Bundle\FixturesBundle\Listener\SuiteLoaderListener" id="sylius_fixtures.listener.suite_loader_listener">
+            <argument type="service" id="sylius_fixtures.suite_registry"/>
+            <argument type="service" id="sylius_fixtures.suite_loader"/>
+
+            <tag name="sylius_fixtures.listener"/>
+        </service>
+     
         <service id="sylius_fixtures.listener.logger" class="Sylius\Bundle\FixturesBundle\Listener\LoggerListener" public="false">
             <argument type="service" id="sylius_fixtures.logger" />
             <tag name="sylius_fixtures.listener" />

--- a/tests/Loader/FixtureListCommandTest.php
+++ b/tests/Loader/FixtureListCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
+
+use Sylius\Bundle\FixturesBundle\Command\FixturesLoadCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class FixtureListCommandTest extends KernelTestCase
+{
+    /** @var CommandTester */
+    private $commandTester;
+
+    protected function setUp()
+    {
+        self::$kernel = static::createKernel();
+        self::$kernel->boot();
+        self::$container = self::$kernel->getContainer();
+
+        self::$container
+            ->get('sylius_fixtures.fixture_registry')
+            ->addFixture(new SampleFixture(self::$container->get('doctrine.orm.default_entity_manager')))
+        ;
+
+        self::$container
+            ->get('sylius_fixtures.suite_registry')
+            ->addSuite('default', [
+                'fixtures'  => $this->createFixture('sample_fixture'),
+                'listeners' => [],
+            ])
+        ;
+
+        $application = new Application(self::$kernel);
+        $application->add(new FixturesLoadCommand());
+        $command = $application->find('sylius:fixtures:list');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    private function createFixture(string $name, array $options = []): array
+    {
+        return [
+            $name => [
+                'name'    => $name,
+                'options' => $options,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_lists_the_available_fixtures(): void
+    {
+        $this->commandTester->execute([]);
+
+        $this->assertSame(
+            'Available suites:
+ - default
+Available fixtures:
+ - sample_fixture
+',
+            $this->commandTester->getDisplay(true)
+        );
+    }
+
+}

--- a/tests/Loader/FixtureListCommandTest.php
+++ b/tests/Loader/FixtureListCommandTest.php
@@ -19,7 +19,7 @@ final class FixtureListCommandTest extends KernelTestCase
 
     protected static $container;
 
-    protected function setUp()
+    public function setUp()
     {
         self::$kernel = static::createKernel();
         self::$kernel->boot();
@@ -47,16 +47,6 @@ final class FixtureListCommandTest extends KernelTestCase
         $this->commandTester = new CommandTester($command);
     }
 
-    private function createFixture(string $name, array $options = []): array
-    {
-        return [
-            $name => [
-                'name'    => $name,
-                'options' => $options,
-            ],
-        ];
-    }
-
     /**
      * @test
      */
@@ -74,4 +64,13 @@ Available fixtures:
         );
     }
 
+    private function createFixture(string $name, array $options = []): array
+    {
+        return [
+            $name => [
+                'name'    => $name,
+                'options' => $options,
+            ],
+        ];
+    }
 }

--- a/tests/Loader/FixtureListCommandTest.php
+++ b/tests/Loader/FixtureListCommandTest.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\FixturesBundle\Command\FixturesLoadCommand;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureRegistry;
+use Sylius\Bundle\FixturesBundle\Suite\LazySuiteRegistry;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -13,19 +16,24 @@ final class FixtureListCommandTest extends KernelTestCase
     /** @var CommandTester */
     private $commandTester;
 
+    protected static $container;
+
     protected function setUp()
     {
         self::$kernel = static::createKernel();
         self::$kernel->boot();
         self::$container = self::$kernel->getContainer();
 
-        self::$container
-            ->get('sylius_fixtures.fixture_registry')
-            ->addFixture(new SampleFixture(self::$container->get('doctrine.orm.default_entity_manager')))
-        ;
+        /** @var FixtureRegistry $fixtureRegistry */
+        $fixtureRegistry = self::$container->get('sylius_fixtures.fixture_registry');
 
-        self::$container
-            ->get('sylius_fixtures.suite_registry')
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::$container->get('doctrine.orm.default_entity_manager');
+        $fixtureRegistry->addFixture(new SampleFixture($entityManager));
+
+        /** @var LazySuiteRegistry $suiteRegistry */
+        $suiteRegistry = self::$container->get('sylius_fixtures.suite_registry');
+        $suiteRegistry
             ->addSuite('default', [
                 'fixtures'  => $this->createFixture('sample_fixture'),
                 'listeners' => [],

--- a/tests/Loader/FixtureListCommandTest.php
+++ b/tests/Loader/FixtureListCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\FixturesBundle\Tests\Loader;

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -116,6 +116,23 @@ final class FixtureLoaderTest extends KernelTestCase
     /**
      * @test
      */
+    public function it_loads_the_suite_with_listeners(): void
+    {
+        $this->getLazySuiteRegistry()
+             ->addSuite('sample', [
+                 'fixtures'  => $this->createConfiguration('sample_fixture'),
+                 'listeners' => $this->createConfiguration('logger'),
+             ])
+        ;
+
+        $this->logger->expects($this->exactly(2))->method('notice')->withAnyParameters();
+
+        $this->commandTester->execute(['suite' => 'sample'], ['interactive' => false]);
+    }
+
+    /**
+     * @test
+     */
     public function it_fails_if_no_default_suite_exist(): void
     {
         $this->expectException(SuiteNotFoundException::class);

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -133,6 +133,29 @@ final class FixtureLoaderTest extends KernelTestCase
     /**
      * @test
      */
+    public function it_loads_the_suite_with_suite_loader_listener(): void
+    {
+        $this->getLazySuiteRegistry()
+            ->addSuite('default', [
+                'fixtures'  => $this->createConfiguration('sample_fixture'),
+                'listeners' => [],
+            ]);
+        $this->getLazySuiteRegistry()
+            ->addSuite('sample', [
+                 'fixtures'  => $this->createConfiguration('sample_fixture'),
+                 'listeners' => $this->createConfiguration('suite_loader', ['options' => ['suites' => ['default']]]),
+             ])
+        ;
+
+        $this->commandTester->execute(['suite' => 'sample'], ['interactive' => false]);
+
+        $connection = $this->em->getConnection();
+        $result = $connection->fetchArray('SELECT count(*) FROM testTable WHERE test_column = "test";');
+        $this->assertSame(2, (int)$result[0]);
+    }
+    /**
+     * @test
+     */
     public function it_fails_if_no_default_suite_exist(): void
     {
         $this->expectException(SuiteNotFoundException::class);
@@ -141,5 +164,3 @@ final class FixtureLoaderTest extends KernelTestCase
     }
 
 }
-
-

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\FixturesBundle\Command\FixturesLoadCommand;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteNotFoundException;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class FixtureLoaderTest extends KernelTestCase
+{
+    /** @var CommandTester */
+    private $commandTester;
+
+    /** @var EntityManagerInterface */
+    private $em;
+
+    protected function setUp()
+    {
+        self::$kernel = static::createKernel();
+        self::$kernel->boot();
+        self::$container = self::$kernel->getContainer();
+
+        $this->em = self::$container->get('doctrine.orm.default_entity_manager');
+        $connection = $this->em->getConnection();
+
+        $connection->exec('CREATE TABLE IF NOT EXISTS testTable (test_column varchar(255) NOT NULL);');
+        $connection->exec('DELETE FROM testTable');
+
+        self::$container
+            ->get('sylius_fixtures.fixture_registry')
+            ->addFixture(new SampleFixture($this->em))
+        ;
+
+        $application = new Application(self::$kernel);
+        $application->add(new FixturesLoadCommand());
+        $command = $application->find('sylius:fixtures:load');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    private function createFixture(string $name, array $options = []): array
+    {
+        return [
+            $name => [
+                'name'    => $name,
+                'options' => $options,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function loads_default_suite_if_none_is_defined(): void
+    {
+        self::$container
+            ->get('sylius_fixtures.suite_registry')
+            ->addSuite('default', [
+                'fixtures'  => $this->createFixture('sample_fixture'),
+                'listeners' => [],
+            ])
+        ;
+
+        $this->commandTester->execute([], ['interactive' => false]);
+
+        $connection = $this->em->getConnection();
+        $result = $connection->fetchArray('SELECT count(*) FROM testTable WHERE test_column = "test";');
+        $this->assertSame(1, (int) $result[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fails_if_no_default_suite_exist(): void
+    {
+        $this->expectException(SuiteNotFoundException::class);
+
+        $this->commandTester->execute([], ['interactive' => false]);
+    }
+
+}
+
+

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -38,7 +38,7 @@ final class FixtureLoaderTest extends KernelTestCase
         return $lazySuiteRegistry;
     }
 
-    protected function setUp()
+    public function setUp()
     {
         self::$kernel = static::createKernel();
         self::$kernel->boot();
@@ -64,16 +64,6 @@ final class FixtureLoaderTest extends KernelTestCase
         $application->add(new FixturesLoadCommand());
         $command = $application->find('sylius:fixtures:load');
         $this->commandTester = new CommandTester($command);
-    }
-
-    private function createConfiguration(string $name, array $options = []): array
-    {
-        return [
-            $name => [
-                'name'    => $name,
-                'options' => $options,
-            ],
-        ];
     }
 
     /**
@@ -126,7 +116,9 @@ final class FixtureLoaderTest extends KernelTestCase
              ])
         ;
 
-        $this->logger->expects($this->exactly(2))->method('notice')->withAnyParameters();
+        /** @var MockObject $logger */
+        $logger = $this->logger;
+        $logger->expects($this->exactly(2))->method('notice')->withAnyParameters();
 
         $this->commandTester->execute(['suite' => 'sample'], ['interactive' => false]);
     }
@@ -162,5 +154,15 @@ final class FixtureLoaderTest extends KernelTestCase
         $this->expectException(SuiteNotFoundException::class);
 
         $this->commandTester->execute([], ['interactive' => false]);
+    }
+
+    private function createConfiguration(string $name, array $options = []): array
+    {
+        return [
+            $name => [
+                'name'    => $name,
+                'options' => $options,
+            ],
+        ];
     }
 }

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
 
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Sylius\Bundle\FixturesBundle\Command\FixturesLoadCommand;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureRegistry;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureRegistryInterface;
+use Sylius\Bundle\FixturesBundle\Suite\LazySuiteRegistry;
 use Sylius\Bundle\FixturesBundle\Suite\SuiteNotFoundException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Webmozart\Assert\Assert;
 
 final class FixtureLoaderTest extends KernelTestCase
 {
@@ -18,22 +24,40 @@ final class FixtureLoaderTest extends KernelTestCase
     /** @var EntityManagerInterface */
     private $em;
 
+    /** @var MockObject|LoggerInterface */
+    private $logger;
+
+    protected static $container;
+
+    public function getLazySuiteRegistry(): LazySuiteRegistry
+    {
+        /** @var LazySuiteRegistry $lazySuiteRegistry */
+        $lazySuiteRegistry = self::$container->get('sylius_fixtures.suite_registry');
+
+        return $lazySuiteRegistry;
+    }
+
     protected function setUp()
     {
         self::$kernel = static::createKernel();
         self::$kernel->boot();
         self::$container = self::$kernel->getContainer();
 
-        $this->em = self::$container->get('doctrine.orm.default_entity_manager');
+        $this->logger = $this->createMock(LoggerInterface::class);
+        self::$container->set('sylius_fixtures.logger', $this->logger);
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::$container->get('doctrine.orm.default_entity_manager');
+        $this->em = $entityManager;
         $connection = $this->em->getConnection();
 
         $connection->exec('CREATE TABLE IF NOT EXISTS testTable (test_column varchar(255) NOT NULL);');
         $connection->exec('DELETE FROM testTable');
 
-        self::$container
-            ->get('sylius_fixtures.fixture_registry')
-            ->addFixture(new SampleFixture($this->em))
-        ;
+        /** @var FixtureRegistry $registry */
+        $registry = self::$container->get('sylius_fixtures.fixture_registry');
+        Assert::isInstanceOf($registry, FixtureRegistryInterface::class);
+        $registry->addFixture(new SampleFixture($this->em));
 
         $application = new Application(self::$kernel);
         $application->add(new FixturesLoadCommand());
@@ -41,7 +65,7 @@ final class FixtureLoaderTest extends KernelTestCase
         $this->commandTester = new CommandTester($command);
     }
 
-    private function createFixture(string $name, array $options = []): array
+    private function createConfiguration(string $name, array $options = []): array
     {
         return [
             $name => [
@@ -56,10 +80,9 @@ final class FixtureLoaderTest extends KernelTestCase
      */
     public function loads_default_suite_if_none_is_defined(): void
     {
-        self::$container
-            ->get('sylius_fixtures.suite_registry')
+        $this->getLazySuiteRegistry()
             ->addSuite('default', [
-                'fixtures'  => $this->createFixture('sample_fixture'),
+                'fixtures'  => $this->createConfiguration('sample_fixture'),
                 'listeners' => [],
             ])
         ;
@@ -68,7 +91,26 @@ final class FixtureLoaderTest extends KernelTestCase
 
         $connection = $this->em->getConnection();
         $result = $connection->fetchArray('SELECT count(*) FROM testTable WHERE test_column = "test";');
-        $this->assertSame(1, (int) $result[0]);
+        $this->assertSame(1, (int)$result[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_the_specified_suite(): void
+    {
+        $this->getLazySuiteRegistry()
+            ->addSuite('sample', [
+                'fixtures'  => $this->createConfiguration('sample_fixture'),
+                'listeners' => [],
+            ])
+        ;
+
+        $this->commandTester->execute(['suite' => 'sample'], ['interactive' => false]);
+
+        $connection = $this->em->getConnection();
+        $result = $connection->fetchArray('SELECT count(*) FROM testTable WHERE test_column = "test";');
+        $this->assertSame(1, (int)$result[0]);
     }
 
     /**

--- a/tests/Loader/FixtureLoaderTest.php
+++ b/tests/Loader/FixtureLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
@@ -162,5 +163,4 @@ final class FixtureLoaderTest extends KernelTestCase
 
         $this->commandTester->execute([], ['interactive' => false]);
     }
-
 }

--- a/tests/Loader/SampleFixture.php
+++ b/tests/Loader/SampleFixture.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Sylius\Bundle\FixturesBundle\Tests\Loader;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+
+final class SampleFixture extends AbstractFixture
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager) {
+        $this->entityManager = $entityManager;
+    }
+
+    public function load(array $options): void
+    {
+        $this->entityManager
+            ->getConnection()
+            ->prepare('INSERT INTO testTable VALUES (?);')
+            ->execute(['test']);
+    }
+
+    public function getName(): string
+    {
+        return 'sample_fixture';
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes 
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | --none--
| License         | MIT

There are no end to end tests for the fixtures. So I wrote some and enabled php unit tests in general.

## Content
* Added missing service definition for suite fixture loader listener
* Adding end to end test for fixture loading
* Adding end to end test for fixture listing
