### PR TITLE
Keep FIFO order in PriorityQueue

### DIFF
--- a/spec/Suite/PriorityQueueSpec.php
+++ b/spec/Suite/PriorityQueueSpec.php
@@ -25,18 +25,20 @@ final class PriorityQueueSpec extends ObjectBehavior
 
     function it_keeps_fifo_order_for_elements_with_same_priority(): void
     {
-        $this->insert(['element' => 1]);
         $this->insert(['element' => 2]);
+        $this->insert(['element' => 1]);
+        $this->insert(['element' => 3]);
 
-        $this->getIterator()->shouldIterateAs([['element' => 1], ['element' => 2]]);
+        $this->getIterator()->shouldIterateAs([['element' => 2], ['element' => 1], ['element' => 3]]);
     }
 
     function it_sorts_elements_by_their_priority(): void
     {
-        $this->insert(['element' => 3], -1);
+        $this->insert(['element' => 1], -1);
         $this->insert(['element' => 2], 0);
-        $this->insert(['element' => 1], 1);
+        $this->insert(['element' => 3], 1);
+        $this->insert(['element' => 4], 0);
 
-        $this->getIterator()->shouldIterateAs([['element' => 1], ['element' => 2], ['element' => 3]]);
+        $this->getIterator()->shouldIterateAs([['element' => 3], ['element' => 2], ['element' => 4], ['element' => 1]]);
     }
 }

--- a/src/Suite/PriorityQueue.php
+++ b/src/Suite/PriorityQueue.php
@@ -25,13 +25,6 @@ final class PriorityQueue implements \IteratorAggregate
      */
     private $records = [];
 
-    /**
-     * @psalm-var array<int, array>
-     *
-     * @var array[]
-     */
-    private $sortedRecords = [];
-
     /** @var bool */
     private $sorted = false;
 
@@ -44,16 +37,19 @@ final class PriorityQueue implements \IteratorAggregate
     public function getIterator(): \Traversable
     {
         if ($this->sorted === false) {
-            // Reversing the records to maintain FIFO order for item with the same priority
-            $this->sortedRecords = array_reverse($this->records);
-
             /** @psalm-suppress InvalidPassByReference Doing PHP magic, it works this way */
-            array_multisort(array_column($this->sortedRecords, 'priority'), \SORT_DESC, $this->sortedRecords);
+            array_multisort(
+                array_column($this->records, 'priority'),
+                \SORT_DESC,
+                array_keys($this->records),
+                \SORT_ASC,
+                $this->records
+            );
 
             $this->sorted = true;
         }
 
-        foreach ($this->sortedRecords as $record) {
+        foreach ($this->records as $record) {
             yield $record['data'];
         }
     }


### PR DESCRIPTION
Sorts them first by priority descending, then by the order in which they were added ascending.