### PR TITLE
Fix doctrine manager registry on ORM Purger listener

### DIFF
--- a/src/Listener/ORMPurgerListener.php
+++ b/src/Listener/ORMPurgerListener.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Bundle\FixturesBundle\Listener;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 final class ORMPurgerListener extends AbstractListener implements BeforeSuiteListenerInterface

--- a/tests/Listener/ORMPurgerListenerTest.php
+++ b/tests/Listener/ORMPurgerListenerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\FixturesBundle\Tests\Listener;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\FixturesBundle\Listener\ORMPurgerListener;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.5 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

Doctrine\Common\Persistence\ManagerRegistry alias has been removed since doctrine/persistence 2.0