### PR TITLE
Update custom listener documentation

### DIFF
--- a/docs/custom_listener.md
+++ b/docs/custom_listener.md
@@ -12,7 +12,7 @@ use Sylius\Bundle\FixturesBundle\Listener\BeforeSuiteListenerInterface;
 use Sylius\Bundle\FixturesBundle\Listener\SuiteEvent;
 use Symfony\Component\Filesystem\Filesystem;
 
-final class DirectoryPurgerListener extends AbstractListener implements ListenerInterface
+final class DirectoryPurgerListener extends AbstractListener implements BeforeSuiteListenerInterface
 {
     public function getName(): string
     {
@@ -26,7 +26,13 @@ final class DirectoryPurgerListener extends AbstractListener implements Listener
 }
 ```
 
-The next step is to register this listener:
+If you want to listen to different/more event(s) instead of BeforeSuiteListenerInterface implement one or more of those interfaces:
+- AfterFixtureListenerInterface
+- AfterSuiteListenerInterface
+- BeforeFixtureListenerInterface
+- BeforeSuiteListenerInterface
+
+The next step is to register this listener ( you can avoid this step when using autoconfiguration ):
 
 ```xml
 <service id="app.listener.directory_purger" class="App\Fixture\DirectoryPurgerListener">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | any since the implementation
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | just doc
| License         | MIT

The current doc is a bit outdated. 

You need to implement the right interface to tell the system which hook should be run.  

Hopefully, that will help someone in the future trying to figure out why their listener is not working.