### PR TITLE
The SymfonyComponentHttpKernelDependencyInjectionExtension class is c…

### DIFF
--- a/src/DependencyInjection/SyliusFixturesExtension.php
+++ b/src/DependencyInjection/SyliusFixturesExtension.php
@@ -22,7 +22,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 final class SyliusFixturesExtension extends Extension implements PrependExtensionInterface
 {


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1
